### PR TITLE
Updated/fixed Spanish translations

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -110,7 +110,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:min="10"
+                        android:min="4"
                         android:max="80"
                         android:contentDescription="@string/sliderVibrationDurationCD" />
 
@@ -135,7 +135,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:min="20"
+                        android:min="8"
                         android:max="160"
                         android:contentDescription="@string/sliderVibrationDurationCD" />
 

--- a/app/src/main/res/layout/dialog_help.xml
+++ b/app/src/main/res/layout/dialog_help.xml
@@ -6,7 +6,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical" >
+        android:orientation="vertical"
+        android:layout_marginHorizontal="10dp">
 
 
         <!-- general information -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -66,15 +66,15 @@
         vibración larga y continua.</string>
     <string name="labelApplicationDescription2">Tactile Clock puede mantenerte informado sobre la hora
         actual de forma automática. La aplicación puede vibrar la hora actual automáticamente cada X minutos o cada hora.</string>
-    <string name="labelApplicationDescription3">También puede reproducir la Señal Horaria de Greenwich (también conocida
-        como \"Pips\") al inicio de cada hora, similar a como lo haría una estación de radio.</string>
+    <string name="labelApplicationDescription3">También puede reproducir la Greenwich Time Signal (también conocida
+        como \"Pips\") al inicio de cada hora, tal y como lo haría una emisora de radio.</string>
     <string name="labelApplicationDescription4">El servicio en segundo plano se inicia automáticamente después del arranque
         del dispositivo.</string>
     <string name="labelVibrationPatternHeading">Patrones de vibración:</string>
     <string name="labelVibrationPatternDescription1">Se distingue entre los siguientes dos patrones de
         vibración:</string>
     <string name="labelVibrationPatternDescription2">Una vibración corta representa el dígito 1 y una vibración larga
-        representa el dígito 5. De está forma, el dígito 2 se representa mediante dos vibraciones cortas consecutivas, el 6 mediante
+        representa el dígito 5. De esta forma, el dígito 2 se representa mediante dos vibraciones cortas consecutivas, el 6 mediante
         una vibración larga y una corta, etc. El 0 se representa mediante dos vibraciones largas.</string>
     <string name="labelTimeFormatExampleHeading">Ejemplos:</string>
     <string name="labelTimeFormatExample1">• 01:18 =  . &#160; .  -...</string>
@@ -82,7 +82,7 @@
     <string name="labelTimeFormatExample3">• 10:11 =  .  -- &#160; .  .</string>
     <string name="labelTimeFormatExample4">• 19:06 =  .  -.... &#160; -.</string>
     <string name="labelTimeFormatExplanationHeading">Explicación:</string>
-    <string name="labelTimeFormatExplanation1">La hora se procesa dígito por dígito.</string>
+    <string name="labelTimeFormatExplanation1">La hora se procesa dígito a dígito.</string>
     <string name="labelTimeFormatExplanation2">El . representa una vibración corta y el - una vibración larga.</string>
     <string name="labelTimeFormatExplanation3">Tanto en las horas como en los minutos se omiten los ceros
         iniciales.</string>
@@ -92,7 +92,7 @@
     <string name="labelTimeFormatGap1">• []:     Corta para la pausa entre dos vibraciones</string>
     <string name="labelTimeFormatGap2">• [ ]:   Media para la separación entre los dígitos en el campo de horas y
         minutos</string>
-    <string name="labelTimeFormatGap3">• [&#160;]: Larga para la pausa entre horas y minutos</string>
+    <string name="labelTimeFormatGap3">• [&#160;&#160;]: Larga para la pausa entre horas y minutos</string>
 
 
     <!-- settings activity -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -30,7 +30,7 @@
     <string name="buttonScreenOffOnErrorVibration">Vibración de advertencia</string>
     <string name="buttonScreenOffOnVibrateTime">Vibrar hora</string>
     <string name="labelScreenOffOnDescription">Qué debe suceder si la pantalla ya está encendida
-        al hacer doble clic en el botón de encendido, causando que se apague y vuelva a encender en
+        al hacer doble clic en el botón de encendido, causando que esta se apague y vuelva a encender en
         lugar de encenderse brevemente y apagarse de nuevo.</string>
 
     <!-- watch fragment -->
@@ -60,22 +60,22 @@
 
     <!-- HelpDialog -->
     <string name="helpDialogTitle">Tutorial</string>
-    <string name="labelApplicationDescription1">Esta aplicación emite la hora actual como patrón de vibración. Para ello,
-        la pantalla debe estar apagada y el botón de encendido debe presionarse dos veces seguidas rápidamente. Si el
+    <string name="labelApplicationDescription1">Esta aplicación vibra la hora actual cuando
+        la pantalla está apagada y se pulsa el botón de encendido dos veces seguidas rápidamente. Si el
         doble clic se ejecuta accidentalmente mientras la pantalla está encendida, la aplicación puede advertir con una
         vibración larga y continua.</string>
-    <string name="labelApplicationDescription2">También puedes usar Tactile Clock para mantenerte informado sobre la hora
-        actual. La aplicación puede vibrar la hora actual automáticamente cada X minutos o cada hora.</string>
-    <string name="labelApplicationDescription3">Además, puede reproducir la Señal Horaria de Greenwich (también conocida
+    <string name="labelApplicationDescription2">Tactile Clock puede mantenerte informado sobre la hora
+        actual de forma automática. La aplicación puede vibrar la hora actual automáticamente cada X minutos o cada hora.</string>
+    <string name="labelApplicationDescription3">También puede reproducir la Señal Horaria de Greenwich (también conocida
         como \"Pips\") al inicio de cada hora, similar a como lo haría una estación de radio.</string>
     <string name="labelApplicationDescription4">El servicio en segundo plano se inicia automáticamente después del arranque
         del dispositivo.</string>
     <string name="labelVibrationPatternHeading">Patrones de vibración:</string>
-    <string name="labelVibrationPatternDescription1">Básicamente, se distingue entre los siguientes dos patrones de
+    <string name="labelVibrationPatternDescription1">Se distingue entre los siguientes dos patrones de
         vibración:</string>
     <string name="labelVibrationPatternDescription2">Una vibración corta representa el dígito 1 y una vibración larga
-        representa el dígito 5. El dígito 2 se representa así mediante dos vibraciones cortas consecutivas, el 6 mediante
-        una vibración larga y una corta, etc. El 0 es una excepción con dos vibraciones largas.</string>
+        representa el dígito 5. De está forma, el dígito 2 se representa mediante dos vibraciones cortas consecutivas, el 6 mediante
+        una vibración larga y una corta, etc. El 0 se representa mediante dos vibraciones largas.</string>
     <string name="labelTimeFormatExampleHeading">Ejemplos:</string>
     <string name="labelTimeFormatExample1">• 01:18 =  . &#160; .  -...</string>
     <string name="labelTimeFormatExample2">• 02:51 =  .. &#160; -  .</string>
@@ -107,9 +107,9 @@
     <string name="labelVibrationSettings">Ajustes de vibración</string>
     <string name="switchMaxStrengthVibrations">Vibrar con intensidad máxima</string>
     <string name="labelShort">Corta</string>
-    <string name="labelShortCD">Corta vibración</string>
+    <string name="labelShortCD">Vibración corta</string>
     <string name="labelLong">Larga</string>
-    <string name="labelLongCD">Larga vibración</string>
+    <string name="labelLongCD">Vibración larga</string>
     <string name="sliderVibrationDurationCD">Duración de vibración</string>
     <string name="labelTestVibrationHeading">Test vibración de hora</string>
     <string name="buttonRefreshTestTime">Actualizar hora</string>
@@ -122,7 +122,7 @@
     <string name="labelEmailAddress">Correo electrónico: %1$s</string>
     <string name="labelWebsite">Esta aplicación es software libre. Puedes encontrar el código fuente en &lt;a href="%1$s"&gt;GitHub&lt;/a&gt;.</string>
     <string name="labelPrivacyHeading">Privacidad</string>
-    <string name="labelPrivacy0">La aplicación de Android Reloj Táctil no requiere conexión a internet.\nTodos los ajustes se almacenan exclusivamente en el propio dispositivo y no se comparten con nadie.</string>
+    <string name="labelPrivacy0">La aplicación Reloj Táctil no requiere conexión a internet.\nTodos los ajustes se almacenan exclusivamente en el propio dispositivo y no se comparten con nadie.</string>
     <string name="labelPrivacy1">La aplicación es software libre y no contiene publicidad.</string>
 
     <!-- service -->
@@ -135,7 +135,7 @@
     <string name="dialogEnabled">Activado</string>
     <string name="dialogDisabled">Desactivado</string>
     <string name="warningDndActive">El modo No molestar está activado</string>
-    <string name="warningRingerModeSilent">El teléfono está en modo silencioso.</string>
+    <string name="warningRingerModeSilent">El teléfono está en modo silencio.</string>
     <string name="warningExactAlarmPermissionMissing">No se pueden programar alarmas exactas. Por favor, comprueba los permisos.</string>
 
     <!--
@@ -145,12 +145,14 @@
     <plurals
         name="milliseconds">
         <item quantity="one">1 ms</item>
+        <item quantity="other">%d ms</item>
         <item quantity="many">%d ms</item>
     </plurals>
 
     <plurals
         name="minutes">
         <item quantity="one">1 minuto</item>
+        <item quantity="other">%d minutos</item>
         <item quantity="many">%d minutos</item>
     </plurals>
 


### PR DESCRIPTION
Some other changes I made:
- Allow to set vibration durations down to 20/40 ms.
- Added side margins to the tutorial dialog.

I saw that my phone represented the medium `[ ]` and long `[&#160;]` gaps as the same size. I added a second `&#160;` to make the difference visible; but feel free to decide how to fix it in other languages to be consistent.